### PR TITLE
Add Laravel 7.x to supported dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
     "require": {
         "php": ">=7.3",
         "graylog2/gelf-php": "^1.5",
-        "illuminate/contracts": "^6.0",
-        "illuminate/log": "^6.0",
-        "illuminate/support": "^6.0"
+        "illuminate/contracts": "^6.0|^7.0",
+        "illuminate/log": "^6.0|^7.0",
+        "illuminate/support": "^6.0|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^8.0",
-        "orchestra/testbench" : "^4.0",
+        "orchestra/testbench" : "^4.0|^5.0",
         "squizlabs/php_codesniffer": "^3.3.2"
     },
     "autoload": {

--- a/tests/Integration/ExampleTest.php
+++ b/tests/Integration/ExampleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Exolnet\Skeleton\Tests\Integration;
+namespace Exolnet\Graylog\Tests\Integration;
 
 class ExampleTest extends TestCase
 {

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Exolnet\Skeleton\Tests\Integration;
+namespace Exolnet\Graylog\Tests\Integration;
 
-use Exolnet\Skeleton\SkeletonServiceProvider;
+use Exolnet\Graylog\GraylogServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
@@ -15,7 +15,7 @@ abstract class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
-            SkeletonServiceProvider::class,
+            GraylogServiceProvider::class,
         ];
     }
 }

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Exolnet\Skeleton\Tests\Unit;
+namespace Exolnet\Graylog\Tests\Unit;
 
 class ExampleTest extends UnitTest
 {

--- a/tests/Unit/UnitTest.php
+++ b/tests/Unit/UnitTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Exolnet\Skeleton\Tests\Unit;
+namespace Exolnet\Graylog\Tests\Unit;
 
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
 abstract class UnitTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
# Description

Add Laravel 7.x to supported dependencies and fix tests
