### PR TITLE
Feature/root acorn compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,14 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, 8.0]
-        laravel: [6.*, 7.*, 8.*]
+        laravel: [^6.10, 7.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
           - laravel: 7.*
             testbench: 5.*
-          - laravel: 6.*
+          - laravel: ^6.10
             testbench: 4.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     "require": {
         "php": "^7.3|^8.0",
         "graylog2/gelf-php": "^1.7",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/log": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/contracts": "^6.10|^7.0|^8.0",
+        "illuminate/log": "^6.10|^7.0|^8.0",
+        "illuminate/support": "^6.10|^7.0|^8.0",
         "monolog/monolog": "^1.24|^2.0"
     },
     "require-dev": {

--- a/src/GraylogServiceProvider.php
+++ b/src/GraylogServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Exolnet\Graylog;
 
 use Exolnet\Graylog\Handler\GraylogHandler;
+use Illuminate\Log\LogManager;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use Monolog\Formatter\GelfMessageFormatter;
@@ -14,24 +15,26 @@ class GraylogServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        Log::extend('graylog', function ($app, array $config) {
-            $defaultConfig = [
-                'handler' => GraylogHandler::class,
-                'handler_with' => [
-                    'transport' => 'udp',
-                    'host' => 'localhost',
-                    'port' => 12201,
-                    'path' => '/gelf',
-                    'extra' => [
-                        //
+        $this->callAfterResolving(LogManager::class, function (LogManager $log) {
+            $log->extend('graylog', function ($app, array $config) {
+                $defaultConfig = [
+                    'handler' => GraylogHandler::class,
+                    'handler_with' => [
+                        'transport' => 'udp',
+                        'host' => 'localhost',
+                        'port' => 12201,
+                        'path' => '/gelf',
+                        'extra' => [
+                            //
+                        ],
                     ],
-                ],
-                'formatter' => GelfMessageFormatter::class,
-            ];
+                    'formatter' => GelfMessageFormatter::class,
+                ];
 
-            $config = array_replace_recursive($defaultConfig, $config);
+                $config = array_replace_recursive($defaultConfig, $config);
 
-            return $this->createMonologDriver($config);
+                return $this->createMonologDriver($config);
+            });
         });
     }
 }


### PR DESCRIPTION
# Description

Instead of using the Log Facade directly in the service provider, use a call after resolving on LogManager in order to support Root Acorn which does not defined the Log Facade as a primary facade.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Unit Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
